### PR TITLE
feat(must): add HandleError for simple error handling

### DIFF
--- a/must.go
+++ b/must.go
@@ -43,6 +43,14 @@ func Handle(h ErrorHandler) func(func() error) {
 	}
 }
 
+func HandleError(h ErrorHandler) func(error) {
+	return func(err error) {
+		if err != nil {
+			h.Handle(err)
+		}
+	}
+}
+
 func Have[T any](c Controller[T]) func(T, error) T {
 	return func(t T, err error) T {
 		return Do(c)(func() (T, error) {


### PR DESCRIPTION
Introduces HandleError function that creates closures for handling errors through the existing ErrorHandler interface without requiring a return value. This complements the existing Controller[T] pattern for cases where error handling is needed but no recovery value is required.

Previously, users had to use Controller[T] even when they only needed to handle errors (like logging or exiting) without returning a value. This forced awkward generic instantiations like Controller[struct{}] for error-only scenarios.

HandleError accepts an ErrorHandler and returns a function that checks for non-nil errors before delegating to the handler's Handle method. This provides a cleaner API for error-only operations while maintaining consistency with the established pattern from commit 2251990.

Typical usage for CLI applications:
```go
handle := HandleError(ExitHandler(1))
handle(mayFailingOperation())
```

This aligns with the library's goal of eliminating error checking boilerplate while maintaining explicit error handling through pluggable strategies.